### PR TITLE
Updated medulo groups

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Estimation of micoglia and monocyte relative cell proportion
 =====================================================================
 
 ### Description:
-We used BRETIGEA (https://github.com/andymckenzie/BRETIGEA ) to find surrogate proportion variables (SPV) of brain cells astrocytes (ast), endothelial cells (end) , microglia (mic) , neurons (neu) , oligodendrocytes (oli) , and oligodendrocyte precursor cells (opc) , derived from each of human, mice, and combination human/mouse data sets.
+We used [BRETIGEA](https://github.com/andymckenzie/BRETIGEA ) to find surrogate proportion variables (SPV) of brain cells astrocytes (ast), endothelial cells (end) , microglia (mic) , neurons (neu) , oligodendrocytes (oli) , and oligodendrocyte precursor cells (opc) , derived from each of human, mice, and combination human/mouse data sets.
 
 In addition to that, we added monocyte marker genes from (PMID:30764877) “F10", "EMILIN2", "F5", "C3", "GDA", "MKI67", "SELL", "HP","FN1","ANXA2","CD24","S100A6","MGST1","SLPI" and monocyte marker genes from xCell (PMID: 29141660) to identify surrogate proportion variables that could be compared across samples. This is an *preliminary/hypothesis-generating* analysis and further tests on true cell proportions are needed for validation.
 
@@ -37,3 +37,5 @@ We ran function findCells() using SVD method to calculate SPVs and all 1000 mark
 ### Run
     bash run_bretigea.sh
 
+### Plots
+[Dropbox](https://www.dropbox.com/sh/hmycsb64ymcc3xm/AAC2PljTFXPTs2Z0GTr_bB-4a?dl=0)

--- a/README.rst
+++ b/README.rst
@@ -42,8 +42,12 @@ We ran function findCells() using SVD method to calculate SPVs and all 1000 mark
 
 `medullo_micro_mono.R`: runs BRETIGEA cell proportion estimation for all subtypes then plots for distribution of relative cell proportion of mococytes and microglia in each medulloblastoma subgroup
 
-Run
----
+Analysis:
+---------
+
+Run the full analysis using:
+
+.. code-block:: bash
     bash run_bretigea.sh
 
 Plots

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,8 @@ Run the full analysis using:
 Estimation of micoglia and monocyte relative cell proportion
 =====================================================================
 
-### Description:
+Description:
+------------
 
 We used (BRETIGEA)[https://github.com/andymckenzie/BRETIGEA] to find surrogate proportion variables (SPV) of brain cells astrocytes (ast), endothelial cells (end) , microglia (mic) , neurons (neu) , oligodendrocytes (oli) , and oligodendrocyte precursor cells (opc) , derived from each of human, mice, and combination human/mouse data sets.
 
@@ -35,8 +36,10 @@ We ran function findCells() using SVD method to calculate SPVs and all 1000 mark
 
 `medullo_micro_mono.R`: runs BRETIGEA cell proportion estimation for all subtypes then plots for distribution of relative cell proportion of mococytes and microglia in each medulloblastoma subgroup
 
-### Run
+Run
+---
     bash run_bretigea.sh
 
-### Plots
+Plots
+-----
 (Dropbox)[https://www.dropbox.com/sh/hmycsb64ymcc3xm/AAC2PljTFXPTs2Z0GTr_bB-4a?dl=0]

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Estimation of micoglia and monocyte relative cell proportion
 Description:
 ------------
 
-We used (BRETIGEA)[https://github.com/andymckenzie/BRETIGEA] to find surrogate proportion variables (SPV) of brain cells astrocytes (ast), endothelial cells (end) , microglia (mic) , neurons (neu) , oligodendrocytes (oli) , and oligodendrocyte precursor cells (opc) , derived from each of human, mice, and combination human/mouse data sets.
+We used BRETIGEA https://github.com/andymckenzie/BRETIGEA to find surrogate proportion variables (SPV) of brain cells astrocytes (ast), endothelial cells (end) , microglia (mic) , neurons (neu) , oligodendrocytes (oli) , and oligodendrocyte precursor cells (opc) , derived from each of human, mice, and combination human/mouse data sets.
 
 In addition to that, we added monocyte marker genes from (PMID:30764877) “F10", "EMILIN2", "F5", "C3", "GDA", "MKI67", "SELL", "HP","FN1","ANXA2","CD24","S100A6","MGST1","SLPI" and monocyte marker genes from xCell (PMID: 29141660) to identify surrogate proportion variables that could be compared across samples. This is an *preliminary/hypothesis-generating* analysis and further tests on true cell proportions are needed for validation.
 
@@ -42,4 +42,4 @@ Run
 
 Plots
 -----
-(Dropbox)[https://www.dropbox.com/sh/hmycsb64ymcc3xm/AAC2PljTFXPTs2Z0GTr_bB-4a?dl=0]
+https://www.dropbox.com/sh/hmycsb64ymcc3xm/AAC2PljTFXPTs2Z0GTr_bB-4a?dl=0

--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,7 @@ Analysis:
 Run the full analysis using:
 
 .. code-block:: bash
+
     bash run_bretigea.sh
 
 Plots

--- a/README.rst
+++ b/README.rst
@@ -21,3 +21,19 @@ Run the full analysis using:
 .. code-block:: bash
 
     bash run_immune-deconv.sh
+
+Estimation of micoglia and monocyte relative cell proportion
+=====================================================================
+
+### Description:
+We used BRETIGEA (https://github.com/andymckenzie/BRETIGEA ) to find surrogate proportion variables (SPV) of brain cells astrocytes (ast), endothelial cells (end) , microglia (mic) , neurons (neu) , oligodendrocytes (oli) , and oligodendrocyte precursor cells (opc) , derived from each of human, mice, and combination human/mouse data sets.
+
+In addition to that, we added monocyte marker genes from (PMID:30764877) “F10", "EMILIN2", "F5", "C3", "GDA", "MKI67", "SELL", "HP","FN1","ANXA2","CD24","S100A6","MGST1","SLPI" and monocyte marker genes from xCell (PMID: 29141660) to identify surrogate proportion variables that could be compared across samples. This is an *preliminary/hypothesis-generating* analysis and further tests on true cell proportions are needed for validation.
+
+We ran function findCells() using SVD method to calculate SPVs and all 1000 marker genes for brain cell types provided in BRETIGEA package along with 317 genes for monocyte. All cell type SPVs were then plotted for each sample as stacked bar plots
+
+`medullo_micro_mono.R`: runs BRETIGEA cell proportion estimation for all subtypes then plots for distribution of relative cell proportion of mococytes and microglia in each medulloblastoma subgroup
+
+### Run
+    bash run_bretigea.sh
+

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,13 @@ Estimation of micoglia and monocyte relative cell proportion
 Description:
 ------------
 
-We used BRETIGEA https://github.com/andymckenzie/BRETIGEA to find surrogate proportion variables (SPV) of brain cells astrocytes (ast), endothelial cells (end) , microglia (mic) , neurons (neu) , oligodendrocytes (oli) , and oligodendrocyte precursor cells (opc) , derived from each of human, mice, and combination human/mouse data sets.
+We used BRETIGEA https://github.com/andymckenzie/BRETIGEA to find surrogate proportion variables (SPV) of brain cells (derived from each of human, mice, and combination human/mouse data sets)
+- astrocytes (ast)
+- endothelial cells (end)
+- microglia (mic)
+- neurons (neu)
+- oligodendrocytes (oli)
+- and oligodendrocyte precursor cells (opc) 
 
 In addition to that, we added monocyte marker genes from (PMID:30764877) “F10", "EMILIN2", "F5", "C3", "GDA", "MKI67", "SELL", "HP","FN1","ANXA2","CD24","S100A6","MGST1","SLPI" and monocyte marker genes from xCell (PMID: 29141660) to identify surrogate proportion variables that could be compared across samples. This is an *preliminary/hypothesis-generating* analysis and further tests on true cell proportions are needed for validation.
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,8 @@ Estimation of micoglia and monocyte relative cell proportion
 =====================================================================
 
 ### Description:
-We used [BRETIGEA](https://github.com/andymckenzie/BRETIGEA ) to find surrogate proportion variables (SPV) of brain cells astrocytes (ast), endothelial cells (end) , microglia (mic) , neurons (neu) , oligodendrocytes (oli) , and oligodendrocyte precursor cells (opc) , derived from each of human, mice, and combination human/mouse data sets.
+
+We used (BRETIGEA)[https://github.com/andymckenzie/BRETIGEA] to find surrogate proportion variables (SPV) of brain cells astrocytes (ast), endothelial cells (end) , microglia (mic) , neurons (neu) , oligodendrocytes (oli) , and oligodendrocyte precursor cells (opc) , derived from each of human, mice, and combination human/mouse data sets.
 
 In addition to that, we added monocyte marker genes from (PMID:30764877) “F10", "EMILIN2", "F5", "C3", "GDA", "MKI67", "SELL", "HP","FN1","ANXA2","CD24","S100A6","MGST1","SLPI" and monocyte marker genes from xCell (PMID: 29141660) to identify surrogate proportion variables that could be compared across samples. This is an *preliminary/hypothesis-generating* analysis and further tests on true cell proportions are needed for validation.
 
@@ -38,4 +39,4 @@ We ran function findCells() using SVD method to calculate SPVs and all 1000 mark
     bash run_bretigea.sh
 
 ### Plots
-[Dropbox](https://www.dropbox.com/sh/hmycsb64ymcc3xm/AAC2PljTFXPTs2Z0GTr_bB-4a?dl=0)
+(Dropbox)[https://www.dropbox.com/sh/hmycsb64ymcc3xm/AAC2PljTFXPTs2Z0GTr_bB-4a?dl=0]

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,6 @@ Run the full analysis using:
 
     bash run_bretigea.sh
 
-Plots
+Plots:
 -----
 https://www.dropbox.com/sh/hmycsb64ymcc3xm/AAC2PljTFXPTs2Z0GTr_bB-4a?dl=0

--- a/code/medullo_micro_mono.R
+++ b/code/medullo_micro_mono.R
@@ -1,4 +1,4 @@
-install.packages("BRETIGEA")
+#install.packages("BRETIGEA")
 library(BRETIGEA)
 library(knitr) #only for visualization
 library(readr)
@@ -44,16 +44,16 @@ theme_Publication <- function(base_size=16, base_family="Helvetica") {
 # assumes to be in R folder of the Dang_MB_2020 repo
 
 #expression v13 
-exp_stranded<-readRDS("../data/raw/pbta-gene-expression-rsem-fpkm-collapsed.stranded.rds")
-exp_polya<-readRDS("../data/raw/pbta-gene-expression-rsem-fpkm-collapsed.polya.rds")
+exp_stranded<-readRDS("data/raw/pbta-gene-expression-rsem-fpkm-collapsed.stranded.rds")
+exp_polya<-readRDS("data/raw/pbta-gene-expression-rsem-fpkm-collapsed.polya.rds")
 # overlapping genes
 overlapgenes<-rownames(exp_stranded[which(rownames(exp_stranded) %in% rownames(exp_polya)),])
 exp<-cbind(exp_stranded[overlapgenes,],exp_polya[overlapgenes,])
 
 #clinical v13
-clinical <- read_tsv("../data/raw/pbta-histologies.tsv",col_types = readr::cols(molecular_subtype = readr::col_character()))
+clinical <- read_tsv("data/raw/rathi_results.tsv")
 # xcell monoctype marker cells
-gene_marker<-read_tsv("../data/raw/13059_2017_1349_MOESM3_ESM.txt") 
+gene_marker<-read_tsv("data/raw/13059_2017_1349_MOESM3_ESM.txt") 
 monocyte_marker<-gene_marker[grep("Monocyte",gene_marker$Celltype_Source_ID),] %>% dplyr::select(-c(`# of genes`,Celltype_Source_ID)) %>% as.data.frame() %>% t() 
 monocyte_marker<-melt(monocyte_marker)
 monocyte_marker<-unique(monocyte_marker$value)
@@ -62,8 +62,11 @@ monocyte_marker<-monocyte_marker[!is.na(monocyte_marker)]
 
 
 
-# select medullo samples
-clinical_medullo<-clinical %>% filter(experimental_strategy=="RNA-Seq" & disease_type_new=="Medulloblastoma")
+# all clinical info for medullo samples
+# pbta
+pbta<-read_tsv("data/raw/pbta-histologies.tsv") %>% dplyr::select(c("Kids_First_Biospecimen_ID","sample_id","RNA_library","tumor_descriptor"))
+clinical_medullo<-clinical %>% left_join(pbta,by=c("Kids_First_Biospecimen_ID","sample_id","RNA_library"))
+#%>% filter(experimental_strategy=="RNA-Seq" & disease_type_new=="Medulloblastoma")
 exp<-exp[,which(colnames(exp) %in% clinical_medullo$Kids_First_Biospecimen_ID)]
 
 # add monocyte/macrophage marker genes https://actaneurocomms.biomedcentral.com/articles/10.1186/s40478-019-0665-y
@@ -79,7 +82,7 @@ cell_type_proportions<-melt(cell_type_proportions)
 
 # add subtypes
 cell_type_proportions<-cell_type_proportions %>% left_join(clinical_medullo ,by=c("Var1"="Kids_First_Biospecimen_ID"))
-write.table(cell_type_proportions,"../data/analyzed/cell_proportions.tsv",sep="\t",quote = FALSE,row.names = FALSE)
+write.table(cell_type_proportions,"data/analyzed/cell_proportions.tsv",sep="\t",quote = FALSE,row.names = FALSE)
 
 # select mic mon
 cell_type_proportions_micro_mono<-cell_type_proportions[which(cell_type_proportions$Var2 %in% c("mic","mon")),]
@@ -89,36 +92,36 @@ cell_type_proportions_micro_mono$tumor_descriptor[which(cell_type_proportions_mi
 cell_type_proportions_micro_mono<-cell_type_proportions_micro_mono[-which(cell_type_proportions_micro_mono$tumor_descriptor=="Unavailable"),]
 
 # count
-count<-table(cell_type_proportions_micro_mono[,c("molecular_subtype","tumor_descriptor")]) %>% as.data.frame()
+count<-table(cell_type_proportions_micro_mono[,c("mb_classifier_prediction","tumor_descriptor")]) %>% as.data.frame()
 count<-count[which(count$Freq>=6),]
 
 # keep only types which have more than 6 counts
 cell_type_proportions_micro_mono_prog<-cell_type_proportions_micro_mono %>%
   filter(tumor_descriptor =="Progressive/Recurrence" &
-           molecular_subtype %in% count[which(count$Freq>=6 & count$tumor_descriptor=="Progressive/Recurrence"),"molecular_subtype"])
+           mb_classifier_prediction %in% count[which(count$Freq>=6 & count$tumor_descriptor=="Progressive/Recurrence"),"mb_classifier_prediction"])
 
 cell_type_proportions_micro_mono_init<-cell_type_proportions_micro_mono %>%
   filter(tumor_descriptor =="Initial CNS Tumor" &
-           molecular_subtype %in% count[which(count$Freq>=6 & count$tumor_descriptor=="Initial CNS Tumor"),"molecular_subtype"])
+           mb_classifier_prediction %in% count[which(count$Freq>=6 & count$tumor_descriptor=="Initial CNS Tumor"),"mb_classifier_prediction"])
 
 cell_type_proportions_micro_mono<-rbind(cell_type_proportions_micro_mono_init,cell_type_proportions_micro_mono_prog)
 
 # microglia and monocyte cell proportions in initial tumor CNS
-pdf("../plots/medullo_micro_mono_init_cells.pdf",width = 12,height = 10)
-ggplot(cell_type_proportions_micro_mono_init,aes(x=Var2,y=value))+geom_violin(alpha=0.65)+stat_compare_means(size=6)+facet_wrap(~molecular_subtype)+xlab("cell type")+ylab("Surrogate proportion variables (SPV)")+theme_Publication()+ggtitle("Cell proportion of microglia and monocyte in initial tumor CNS")+ scale_x_discrete(labels= c("Microglia","Monocytes"))+geom_point(aes(color=tumor_descriptor,shape=tumor_descriptor), size=1,position = position_jitterdodge())+ylim(-0.5,0.5)
+pdf("plots/medullo_micro_mono_init_cells.pdf",width = 12,height = 10)
+ggplot(cell_type_proportions_micro_mono_init,aes(x=Var2,y=value))+geom_violin(alpha=0.65)+stat_compare_means(size=6)+facet_wrap(~mb_classifier_prediction)+xlab("cell type")+ylab("Surrogate proportion variables (SPV)")+theme_Publication()+ggtitle("Cell proportion of microglia and monocyte in initial tumor CNS")+ scale_x_discrete(labels= c("Microglia","Monocytes"))+geom_point(aes(color=tumor_descriptor,shape=tumor_descriptor), size=1,position = position_jitterdodge())+ylim(-0.5,0.5)
 dev.off()
 
-tiff("../plots/medullo_micro_mono_init_cells.tiff",width = 2000,height = 1600,res=150)
-ggplot(cell_type_proportions_micro_mono_init,aes(x=Var2,y=value))+geom_violin(alpha=0.65)+stat_compare_means(size=6)+facet_wrap(~molecular_subtype)+xlab("cell type")+ylab("Surrogate proportion variables (SPV)")+theme_Publication()+ggtitle("Cell proportion of microglia and monocyte in initial tumor CNS")+ scale_x_discrete(labels= c("Microglia","Monocytes"))+geom_point(aes(color=tumor_descriptor,shape=tumor_descriptor), size=1,position = position_jitterdodge())+ylim(-0.5,0.5)
+tiff("plots/medullo_micro_mono_init_cells.tiff",width = 2000,height = 1600,res=150)
+ggplot(cell_type_proportions_micro_mono_init,aes(x=Var2,y=value))+geom_violin(alpha=0.65)+stat_compare_means(size=6)+facet_wrap(~mb_classifier_prediction)+xlab("cell type")+ylab("Surrogate proportion variables (SPV)")+theme_Publication()+ggtitle("Cell proportion of microglia and monocyte in initial tumor CNS")+ scale_x_discrete(labels= c("Microglia","Monocytes"))+geom_point(aes(color=tumor_descriptor,shape=tumor_descriptor), size=1,position = position_jitterdodge())+ylim(-0.5,0.5)
 dev.off()
 
 # black and white
-pdf("../plots/medullo_micro_mono_init_cells_bw.pdf",width = 12,height = 10)
-ggplot(cell_type_proportions_micro_mono_init,aes(x=Var2,y=value))+geom_violin(alpha=0.65)+stat_compare_means(size=6)+facet_wrap(~molecular_subtype)+xlab("cell type")+ylab("Surrogate proportion variables (SPV)")+theme_Publication()+ggtitle("Cell proportion of microglia and monocyte in initial tumor CNS")+ scale_x_discrete(labels= c("Microglia","Monocytes"))+scale_fill_grey()+geom_point(aes(shape=tumor_descriptor),size=1 ,position = position_jitterdodge())+ylim(-0.5,0.5)
+pdf("plots/medullo_micro_mono_init_cells_bw.pdf",width = 12,height = 10)
+ggplot(cell_type_proportions_micro_mono_init,aes(x=Var2,y=value))+geom_violin(alpha=0.65)+stat_compare_means(size=6)+facet_wrap(~mb_classifier_prediction)+xlab("cell type")+ylab("Surrogate proportion variables (SPV)")+theme_Publication()+ggtitle("Cell proportion of microglia and monocyte in initial tumor CNS")+ scale_x_discrete(labels= c("Microglia","Monocytes"))+scale_fill_grey()+geom_point(aes(shape=tumor_descriptor),size=1 ,position = position_jitterdodge())+ylim(-0.5,0.5)
 dev.off()
 
-tiff("../plots/medullo_micro_mono_init_cells_bw.tiff",width = 2000,height = 1600,res=150)
-ggplot(cell_type_proportions_micro_mono_init,aes(x=Var2,y=value))+geom_violin(alpha=0.65)+stat_compare_means(size=6)+facet_wrap(~molecular_subtype)+xlab("cell type")+ylab("Surrogate proportion variables (SPV)")+theme_Publication()+ggtitle("Cell proportion of microglia and monocyte in initial tumor CNS")+ scale_x_discrete(labels= c("Microglia","Monocytes"))+scale_fill_grey()+geom_point(aes(shape=tumor_descriptor),size=1 ,position = position_jitterdodge())+ylim(-0.5,0.5)
+tiff("plots/medullo_micro_mono_init_cells_bw.tiff",width = 2000,height = 1600,res=150)
+ggplot(cell_type_proportions_micro_mono_init,aes(x=Var2,y=value))+geom_violin(alpha=0.65)+stat_compare_means(size=6)+facet_wrap(~mb_classifier_prediction)+xlab("cell type")+ylab("Surrogate proportion variables (SPV)")+theme_Publication()+ggtitle("Cell proportion of microglia and monocyte in initial tumor CNS")+ scale_x_discrete(labels= c("Microglia","Monocytes"))+scale_fill_grey()+geom_point(aes(shape=tumor_descriptor),size=1 ,position = position_jitterdodge())+ylim(-0.5,0.5)
 dev.off()
 
 
@@ -126,22 +129,22 @@ dev.off()
 
 
 # all brain cells in BRETIGA compared for all subtypes
-# group by molecular_subtype and arrange by value
-cell_type_proportions<-cell_type_proportions %>% group_by(molecular_subtype) %>% arrange(desc(value))
+# group by mb_classifier_prediction and arrange by value
+cell_type_proportions<-cell_type_proportions %>% group_by(mb_classifier_prediction) %>% arrange(desc(value))
 cell_type_proportions$tumor_descriptor[which(cell_type_proportions$tumor_descriptor %in% c("Recurrence","Progressive"))]<-"Progressive/Recurrence"
 
 cell_type_proportions_init<-cell_type_proportions %>% filter(tumor_descriptor =="Initial CNS Tumor")
 cell_type_proportions_prog<-cell_type_proportions %>% filter(tumor_descriptor =="Progressive/Recurrence")  
   
-pdf("../plots/medullo_all_brain_cells.pdf",width = 25,height = 10)
+pdf("plots/medullo_all_brain_cells.pdf",width = 25,height = 10)
 ggplot(cell_type_proportions,aes(x=Var1,y=value,fill=fct_reorder(Var2,value,.desc=TRUE)))+geom_bar(stat = "identity")+xlab("Sample")+ylab("Surrogate proportion variables (SPV)")+theme_Publication()+ggtitle("All brain cells in BRETIGEA compared for all CNS in subtypes")+theme(axis.text.x = element_text(size=12,color="black",face="bold",angle = 90))+guides(fill=guide_legend(title="cell types"))
 dev.off()
 
-tiff("../plots/medullo_all_brain_cells.tiff",width = 3500,height = 1200,res=150)
+tiff("plots/medullo_all_brain_cells.tiff",width = 3500,height = 1200,res=150)
 ggplot(cell_type_proportions,aes(x=Var1,y=value,fill=fct_reorder(Var2,value,.desc=TRUE)))+geom_bar(stat = "identity")+xlab("Sample")+ylab("Surrogate proportion variables (SPV)")+theme_Publication()+ggtitle("All brain cells in BRETIGEA compared for all CNS in subtypes")+theme(axis.text.x = element_text(size=12,color="black",face="bold",angle = 90))+guides(fill=guide_legend(title="cell types"))
 dev.off()
 
 
 
-write.table(markers_df_brain,"../data/analyzed/marker_df_brain.tsv",sep="\t",quote = FALSE,row.names = FALSE)
+write.table(markers_df_brain,"data/analyzed/marker_df_brain.tsv",sep="\t",quote = FALSE,row.names = FALSE)
 


### PR DESCRIPTION
## Description

The PR updates the medullo groups from #2  and regenerates the plots  comparing monocyte and microglia relative cell proportions from BRETIGEA

## Requests for reviewers to check/confirm
v13 version RNAseq files were used here (I don't think any were updated since v13 in OpenPBTA) just wanted to make sure that the version is correct

I had to use the v13 pbta histology file to capture the tumor_descriptor needed for the plots so I added the pbta histology without the molecular_subtype column. The groups in the plot are from `mb_classifier_prediction` from `rathi_results.tsv` #2 


